### PR TITLE
Stencils for operators on Voronoi spheres. 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ SHTnsSpheres = "9e5c175a-5132-4517-85a1-2957ec255f89"
 SHTnsSpheres_Ext = ["SHTnsSpheres"]
 
 [compat]
-ManagedLoops = "0.1"
+ManagedLoops = "0.1.8"
 PackageExtensionCompat = "1"
 SHTnsSpheres = "0.2.4"
 julia = "1.8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CFDomains"
 uuid = "3699aaca-035b-4155-96ec-eecb526248de"
 authors = ["The ClimFlows contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 ManagedLoops = "36a4119d-6b73-4371-88fe-ba2d91f5495d"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,5 +10,5 @@ Documentation for [CFDomains](https://github.com/ClimFlows/CFDomains.jl).
 ```
 
 ```@autodocs
-Modules = [CFDomains, CFDomains.VerticalInterpolation]
+Modules = [CFDomains, CFDomains.VerticalInterpolation, CFDomains.Stencils]
 ```

--- a/src/CFDomains.jl
+++ b/src/CFDomains.jl
@@ -223,6 +223,8 @@ struct SubMesh{sym,Dom<:UnstructuredDomain} <: UnstructuredDomain
 end
 @inline SubMesh(sym::Symbol, dom::D) where {D} = SubMesh{sym,D}(dom)
 
+include("julia/voronoi_stencils.jl")
+
 include("julia/VoronoiSphere.jl")
 
 shell(nz, layer::VoronoiSphere) = Shell(nz, layer, VHLayout())

--- a/src/julia/voronoi_stencils.jl
+++ b/src/julia/voronoi_stencils.jl
@@ -1,0 +1,155 @@
+module Stencils
+
+using ManagedLoops: @unroll
+
+macro gen(expr)
+    esc(:(Base.@propagate_inbounds @generated $expr))
+end
+
+macro inl(expr)
+    esc(:(Base.@propagate_inbounds $expr))
+end
+
+"""
+    g = Fix(f, args)
+Return callable `g` such that `g(x,...)` calls `f` by prepending `args...` before `x...`:
+
+    g(x...) == f(args..., x...)
+This is similar to `Base.Fix1`, with several arguments.
+"""
+struct Fix{Fun,Coefs}
+    fun::Fun # operator to call
+    coefs::Coefs # local mesh information
+end
+@inl (st::Fix)(args...) = st.fun(st.coefs..., args...)
+
+#======================== averaging =======================#
+
+# cell -> edge
+@inl average_ie(vsphere, ij) =
+    Fix(get_average_ie, (vsphere.edge_left_right[1, ij], vsphere.edge_left_right[2, ij]))
+
+@inl get_average_ie(left, right, mass, k) = (mass[k, left] + mass[k, right]) / 2
+
+# cell -> vertex
+@inl function average_iv(vsphere, ij::Int)
+    cells = @unroll (vsphere.dual_vertex[e, ij] for e = 1:3)
+    weights = @unroll (vsphere.Riv2[e, ij] for e = 1:3)
+    return Fix(get_average_iv, (cells, weights))
+end
+@inl get_average_iv(cells, weights, mass, k) =
+    @unroll sum(weights[e] * mass[k, cells[e]] for e = 1:3)
+
+# vertex -> edge
+@inl average_ve(vsphere, ij::Int) =
+    Fix(get_average_ve, (vsphere.edge_down_up[1, ij], vsphere.edge_down_up[2]))
+
+@inl get_average_ve(up, down, qv, k) = (qv[k, down] + qv[k, up]) / 2
+
+
+#======================= dot product ======================#
+
+"""
+    dot_prod = dot_product(vsphere::VoronoiSphere, ij, v::Val{N})
+
+Return the callable `dot_prod` which knows how to compute a dot product
+at primal cell `ij` of `sphere`. `N=sphere.primal_deg[ij]` is the number of edges
+and must be provided as a compile-time constant for performance.
+`dot_prod` is to be used as:
+
+    dp_ij = dot_prod(ucov::V, vcov::V) # single layer, V<:AbstractVector
+    dp_ijk = dot_prod(ucov::M, vcov::M, k) # multi-layer, M<:AbstractMatrix
+
+The dot product is with respect to the unit sphere and `vcov, ucov`
+represent covariant vector fields (1-forms).
+
+@inbounds may be specified at either or both call sites, and will propagate, as in:
+    # do not check bounds when accessing mesh data
+    dot_prod = @inbounds dot_product(sphere::VoronoiSphere, ij, v::Val{N})
+    # do not check bounds when accessing ucov, vcov
+    dp_ij = @inbounds dot_prod(ucov::V, vcov::V)
+
+"""
+@gen dot_product(vsphere, ij, v::Val{N}) where {N} = quote
+    # the factor 1/2 for the Perot formula is incorporated into inv_area
+    # inv_area is incorporated into hodges
+    inv_area = inv(2 * vsphere.Ai[ij])
+    edges = @unroll (vsphere.primal_edge[e, ij] for e = 1:$N)
+    hodges = @unroll (inv_area * vsphere.le_de[edges[e]] for e = 1:$N)
+    return Fix(get_dot_product, (v, edges, hodges))
+end
+
+@gen get_dot_product(::Val{N}, edges, hodges, ucov, vcov, k) where {N} = quote
+    @unroll sum(hodges[e] * (ucov[k, edges[e]] * vcov[k, edges[e]]) for e = 1:$N)
+end
+
+#======================= centered flux ======================#
+
+"""
+    cflux = centered_flux(vsphere, ij::Int)
+    flux[ij] = flux(mass, ucov)         # single-layer
+    flux[k, ij] = flux(mass, ucov, k)   # multi-layer
+
+Two-step computation of centered flux at edge `ij` of `vsphere`.
+"""
+@inl function centered_flux(vsphere, ij::Int)
+    # le_de includes the factor 1/2 for the centered average
+    left_right, le_de = vsphere.edge_left_right, vsphere.le_de
+    Fix(get_centered_flux, (ij, left_right[1, ij], left_right[2, ij], le_de[ij] / 2))
+end
+
+# Makes sense for a conformal metric.
+# It is the job of the caller to multiply the covariant velocity
+# `ucov` (which has units m^2/s), or the flux, by the
+# contravariant metric factor (which has units m^-2) so that,
+# if mass is in kg, the flux and its divergence are in kg/s.
+@inl get_centered_flux(ij, left, right, le_de, mass, ucov, k) =
+    le_de * ucov[k, ij] * (mass[k, left] + mass[k, right])
+@inl get_centered_flux(ij, left, right, le_de, mass, ucov) =
+    le_de * ucov[ij] * (mass[left] + mass[right])
+
+#========================= divergence =======================#
+
+# flux must be a contravariant vector density = 2-form in 3D space
+# in X/s for the flux of X
+
+# signs include the inv_area factor
+@gen divergence(vsphere, ij::Int, v::Val{N}) where {N} = quote
+    inv_area = inv(vsphere.Ai[ij])
+    edges = @unroll (vsphere.primal_edge[e, ij] for e = 1:$N)
+    signs = @unroll (inv_area * vsphere.primal_ne[e, ij] for e = 1:$N)
+    return Fix(get_divergence, (v, edges, signs))
+end
+
+@gen get_divergence(::Val{N}, edges, signs, flux, k) where {N} = quote
+    @unroll sum(flux[k, edges[e]] * signs[e] for e = 1:$N)
+end
+
+#========================= curl =====================#
+
+@inl function curl(vsphere, ij::Int)
+    F = eltype(vsphere.Riv2)
+    edges = @unroll (vsphere.dual_edge[e, ij] for e = 1:3)
+    signs = @unroll (F(vsphere.dual_ne[e, ij]) for e = 1:3)
+    return Fix(get_curl, (edges, signs))
+end
+
+@inl get_curl(edges, signs, ucov, k) = @unroll sum(ucov[k, edges[e]] * signs[e] for e = 1:3)
+
+#========================= gradient =====================#
+
+@inl gradient(vsphere, ij::Int) =
+    Fix(get_gradient, (vsphere.edge_left_right[1, ij], vsphere.edge_left_right[2, ij]))
+
+@inl get_gradient(left, right, q, k) = q[k, right] - q[k, left]
+
+#=========================== TRiSK ======================#
+
+# weight inclues the factor 1/2 of the centered average of qe
+@inl TRiSK(vsphere, ij::Int, edge::Int) =
+    Fix(get_TRiSK, (ij, vsphere.trisk[edge, ij], vsphere.wee[edge, ij] / 2))
+
+@inl get_TRiSK(ij, edge, weight, du, U, qe, k) =
+    muladd(weight * U[k, edge], qe[k, ij] + qe[k, edge], du[k, ij])
+
+end #===== module ====#

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,9 @@
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+ClimFlowsData = "f57ce217-a21f-4063-8e40-561e9bf56723"
+LoopManagers = "d33d4f76-8fbe-47a6-acd9-ead534c583ff"
+ManagedLoops = "36a4119d-6b73-4371-88fe-ba2d91f5495d"
+NetCDF = "30363a11-5582-574a-97bb-aa9a979735b9"
 SHTnsSpheres = "9e5c175a-5132-4517-85a1-2957ec255f89"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+ThreadPinning = "811555cd-349b-4f26-b7bc-1f208b848042"

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -1,0 +1,47 @@
+choices = (precision=Float32, meshname = "uni.1deg.mesh.nc")
+reader = DYNAMICO_reader(ncread, choices.meshname)
+sphere = VoronoiSphere(reader; prec = choices.precision)
+@info sphere
+
+function trisk_one_step(mgr, qU, sphere, q, U)
+    @with mgr,
+    let krange = axes(qU,1)
+        @inbounds for ij in axes(qU, 2)
+            deg = sphere.trisk_deg[ij]
+            @unroll deg in 9:10 begin
+                trisk = Stencils.TRiSK(sphere, ij, Val(deg))
+                @vec for k in krange
+                    qU[k, ij] = trisk(U, q, k)
+                end
+            end
+        end
+    end
+end
+
+function trisk_many_steps(mgr, qU, sphere, q, U)
+    @with mgr,
+    let krange = axes(qU,1)
+        @inbounds for ij in axes(qU, 2)
+            deg = sphere.trisk_deg[ij]
+            qU[:, ij] .= 0
+            for edge in 1:deg
+                trisk = Stencils.TRiSK(sphere, ij, edge)
+                @vec for k in krange
+                    qU[k, ij] = trisk(qU, U, q, k)
+                end
+            end
+        end
+    end
+end
+
+qU, q, U = (randn(Float32, 64, length(sphere.le_de)) for _=1:3)
+vlen(::VectorizedCPU{N}) where N = N
+N = vlen(VectorizedCPU()) # native vector size for Float32
+(f1, f2) = trisk_one_step, trisk_many_steps
+
+for (fun, vlen, nt) in [(f2, N, 1), (f1, N, 1), (f1, 2N, 1), (f1, N, 2), (f1, N, 4)]
+    mgr = VectorizedCPU(vlen)
+    mgr = (nt == 1) ? mgr : MultiThread(mgr, nt)
+    @info "$fun on $mgr"
+    @btime $fun($mgr, $qU, $sphere, $q, $U)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,14 @@
-using CFDomains
+using ThreadPinning
+pinthreads(:cores)
+using NetCDF: ncread
+using BenchmarkTools
+
+using LoopManagers: VectorizedCPU, MultiThread
+using ManagedLoops: @with, @vec, @unroll
 using SHTnsSpheres: SHTnsSphere
+using CFDomains: CFDomains, Stencils, VoronoiSphere
+using ClimFlowsData: DYNAMICO_reader
+
 using Test
 
 @testset "CFDomains.jl" begin
@@ -8,5 +17,8 @@ using Test
     sph = SHTnsSphere(nlat)
     @info CFDomains.data_layout(sph)
 
+
     # Write your tests here.
 end
+
+include("benchmark.jl")


### PR DESCRIPTION
Finite-difference operators on Voronoi meshes are implemented. A two-step approach is used, whereby mesh-related quantities used in the computation at a single grid point are fetched first, and the computation for that point is done in a second time, given the input arrays. This allows reusing the mesh information in multi-layer settings, encapsulates low-level details and preserves performance.
 