### PR TITLE
Stencils.dot_product: extract relevant fields

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CFDomains"
 uuid = "3699aaca-035b-4155-96ec-eecb526248de"
 authors = ["The ClimFlows contributors"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 ManagedLoops = "36a4119d-6b73-4371-88fe-ba2d91f5495d"

--- a/src/julia/voronoi_stencils.jl
+++ b/src/julia/voronoi_stencils.jl
@@ -244,7 +244,8 @@ end
 #======================= dot product ======================#
 
 """
-    dot_prod = dot_product(vsphere::VoronoiSphere, cell::Int, v::Val{N})
+    vsphere = dot_product(vsphere::VoronoiSphere) # optional, returns only relevant fields as a named tuple
+    dot_prod = dot_product(vsphere, cell::Int, v::Val{N})
 
     # $(SINGLE(:ucov, :vcov))
     dp[cell] = dot_prod(ucov, vcov) 
@@ -259,6 +260,11 @@ $NEDGE
 
 $(INB(:dot_product, :dot_prod))
 """
+function dot_product(vsphere) 
+    (; Ai, primal_edge, le_de) = vsphere
+    return (; Ai, primal_edge, le_de)
+end
+
 @gen dot_product(vsphere, ij, v::Val{N}) where {N} = quote
     # the factor 1/2 for the Perot formula is incorporated into inv_area
     # inv_area is incorporated into hodges


### PR DESCRIPTION
oneAPI has a low limit on the amount of arguments that can be passed to kernels. Passing only the relevant fields instead of the whole sphere object is useful to remain below that limit.

 
